### PR TITLE
Remove "50,000 Ko", is not actually in the audio

### DIFF
--- a/pepper-and-carrot-ep6.msrt
+++ b/pepper-and-carrot-ep6.msrt
@@ -511,7 +511,7 @@
 00:02:50,870 --> 00:02:56,460
 [rus] Обладателя главного приза определят Ваши аплодисменты!
 [dan] Stemmerne vil bliver talt op af klap-o-metereret
-[eng] The winner of the grand prize of 50,000 Ko will be determined by applaud-o-meter!
+[eng] The winner of the grand prize will be determined by applaud-o-meter!
 [epo] La voĉdonado fariĝos per la aplaŭdado!
 [jbo] .i ca'e ba jdice fi le jinga ta'i le nu mi'o cladu zanru
 [fra] La gagnante sera déterminé à l'applaudimètre


### PR DESCRIPTION
The audio doesn't actually mention the prize value, so this removes it from the subtitles as well.