### PR TITLE
Add travis automatic srt generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+os: linux
+python: "3.6"
+
+script:
+  - $TRAVIS_BUILD_DIR/tool/generate-srt.sh
+
+after_success:
+  - 'if [ $TRAVIS_EVENT_TYPE == "push" ]; then
+      $TRAVIS_BUILD_DIR/tool/deploy-srt.sh;
+    fi'

--- a/tool/deploy-srt.sh
+++ b/tool/deploy-srt.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+cd "${TRAVIS_BUILD_DIR}"
+
+git config --global push.default simple
+git config user.name "Travis CI"
+git config user.email "travis@travis-ci.org"
+
+git checkout "${TRAVIS_BRANCH}"
+git add --all
+git commit -m "Extract srt files for commit: ${TRAVIS_COMMIT}" -m "Travis build: ${TRAVIS_BUILD_NUMBER} [ci skip]"
+git push "https://${GH_REPO_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git" "${TRAVIS_BRANCH}"

--- a/tool/generate-srt.sh
+++ b/tool/generate-srt.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -23,23 +23,14 @@ extractLanguages () {
   # Extract languages from list 1 at a time
   local lang
   for lang in ${langs}; do
-    #if [[ -n $lang ]]; then
-      echo "Generating $lang for $file"
-      [ -d "${BASE_DIR}/output/$file" ] || mkdir -p "${BASE_DIR}/output/$file"
-      echo "$lang" "${BASE_DIR}/output/$file/$file-$lang.srt" "${BASE_DIR}/$file.msrt"
-      "${SCRIPT_DIR}/msrt_tool.py" --extract "$lang" "${BASE_DIR}/output/$file/$file-$lang.srt" "${BASE_DIR}/$file.msrt"
-    #fi
+    echo "Generating $lang for $file"
+    [ -d "${BASE_DIR}/output/$file" ] || mkdir -p "${BASE_DIR}/output/$file"
+    "${SCRIPT_DIR}/msrt_tool.py" --extract "$lang" "${BASE_DIR}/output/$file/$file-$lang.srt" "${BASE_DIR}/$file.msrt"
   done
 }
 
-FILES=("pepper-and-carrot-ep6" "morevna-ep3")
+FILES=( "pepper-and-carrot-ep6" "morevna-ep3" )
 
 for FILE in "${FILES[@]}"; do
   extractLanguages "$FILE"
 done
-
-#FILE="synfig-course-promo"
-#for LANG in rus eng epo spa; do
-#[ -d "${BASE_DIR}/output/${FILE}" ] || mkdir -p "${BASE_DIR}/output/${FILE}"
-#python ${SCRIPT_DIR}/msrt_tool.py ${FILE}.msrt --extract ${LANG} ${BASE_DIR}/output/${FILE}/${FILE}-${LANG}.srt
-#done


### PR DESCRIPTION
This will use Travis to automatically commit updates to the srt files when changes to the msrt files are pushed. Before this will work properly, @morevnaproject will need to sign into [Travis CI](https://travis-ci.org/) and enable travis integration for this repository. Then generate a Github access token and either add it to the .travis.yml file with these commands in the main repo directory:
```bash
gem install travis
travis encrypt --add -repo morevnaproject/subtitles-translation GH_REPO_TOKEN=<access_token>
```
or by adding it to the environment variables section of the travis repository settings with the name GH_REPO_TOKEN and the value of your personal access token.